### PR TITLE
...with tests!

### DIFF
--- a/invoker.xs
+++ b/invoker.xs
@@ -40,7 +40,18 @@ invoker_ck_entersub(pTHX_ OP *o, void *ud) {
 
 	    const PADOFFSET tmp = pad_findmy("$self", 5, 0);
             if (tmp == -1) {
-                croak("$self not found");
+                gv = gv_fetchpvn_flags("self", 4, GV_NOINIT, SVt_PV);
+                if (SvOK(gv) && SvTYPE(gv) == SVt_PVGV) {
+                    // "$self" was defined as a package variable -- use it
+                    cUNOPx(arg)->op_first = newGVOP(
+                        gvop->op_type,
+                        gvop->op_flags,
+                        gv
+                    );
+                }
+                else {
+                    croak("$self not found");
+                }
             }
             else {
                 OP * const self = newOP(OP_PADSV, 0);

--- a/t/03ourself.t
+++ b/t/03ourself.t
@@ -1,0 +1,137 @@
+#!/usr/bin/perl -w
+use strict;
+
+package submain;
+our @ISA = ('main');
+sub foo {
+    push @main::foo, ['submain', @_ ]
+}
+
+package main;
+use vars '$self';
+
+use Test::More;
+
+our @foo;
+
+sub foo {
+    push @foo, \@_;
+}
+{
+    # XXX: using string eval blows up b::hooks::parser here
+    my $sub = eval { sub {
+                     use invoker;
+                     sub {
+                         $self = shift;
+                         $->foo("x", @_);
+                     }
+                 }} ;
+    ok($sub);
+    diag $@ if $@;
+
+    $self = bless {}, 'main';
+    $sub->()->($self, 1,2);
+
+    my $subself = bless {}, 'submain';
+    $sub->()->($subself, 1,2);
+
+    is_deeply(\@foo, [[$self, 'x', 1,2],
+                      ['submain', $subself, 'x', 1, 2]]);
+}
+
+{
+    @foo = ();
+    my $sub = eval q{ sub {
+                     use invoker;
+                     sub {
+                         $self = shift;
+                         $->foo;
+                     }
+                 } };
+    ok($sub);
+    diag $@ if $@;
+
+    $self = bless {}, 'main';
+    $sub->()->($self, 1,2);
+
+    my $subself = bless {}, 'submain';
+    $sub->()->($subself, 1,2);
+
+    is_deeply(\@foo, [[$self],
+                      ['submain', $subself]]);
+}
+
+{
+    @foo = ();
+    my $sub = eval q{ sub {
+                     use invoker;
+                     sub {
+                         $self = shift;
+                         $->bar('x');
+                     }
+                 } };
+
+    no warnings 'once';
+    *bar = sub {
+        push @foo, ['bar', @_];
+    };
+    ok($sub);
+    diag $@ if $@;
+
+    $self = bless {}, 'main';
+    $sub->()->($self, 1,2);
+
+    my $subself = bless {}, 'submain';
+    $sub->()->($subself, 1,2);
+
+    is_deeply(\@foo, [['bar', $self, 'x'],
+                      ['bar', $subself, 'x']]);
+    @foo = ();
+}
+
+{
+    @foo = ();
+    my $sub = eval q{ sub {
+                     use invoker;
+                     my $name = 'bar';
+                     sub {
+                         $self = shift;
+                         $->$name;
+                     }
+                 } };
+
+
+    ok($sub);
+    diag $@ if $@;
+
+    $self = bless {}, 'main';
+    $sub->()->($self, 1,2);
+
+    my $subself = bless {}, 'submain';
+    $sub->()->($subself, 1,2);
+
+    is_deeply(\@foo, [['bar', $self],
+                      ['bar', $subself]]);
+    @foo = ();
+}
+
+{
+    package Les::Autres;
+    @foo = ();
+    my $sub = eval q{ sub {
+                     use invoker;
+                     my $name = 'bar';
+                     sub {
+                         $->$name;
+                     }
+                 } };
+
+
+    package main;
+    ok(!$sub);
+    like($@, qr'\$self not found');
+
+}
+
+
+done_testing;


### PR DESCRIPTION
- Use $self if it's not in lexical pad but already introduced as a package variable.
  (Still fails with the same error if it's not found in lexical nor package scope.)
